### PR TITLE
adjust schema URI with CRIM-ca org and MLM repo + add bump-my-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hackmd-github-sync-badge](https://hackmd.io/lekSD_RVRiquNHRloXRzeg/badge)](https://hackmd.io/lekSD_RVRiquNHRloXRzeg?both)
 
 - **Title:** Machine Learning Model Extension
-- **Identifier:** [https://stac-extensions.github.io/mlm/v1.0.0/schema.json](https://stac-extensions.github.io/mlm/v1.0.0/schema.json)
+- **Identifier:** [https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json](https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json)
 - **Field Name Prefix:** mlm
 - **Scope:** Collection, Item, Asset, Links
 - **Extension Maturity Classification:** Proposal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hackmd-github-sync-badge](https://hackmd.io/lekSD_RVRiquNHRloXRzeg/badge)](https://hackmd.io/lekSD_RVRiquNHRloXRzeg?both)
 
 - **Title:** Machine Learning Model Extension
-- **Identifier:** [https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json](https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json)
+- **Identifier:** [https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json](https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json)
 - **Field Name Prefix:** mlm
 - **Scope:** Collection, Item, Asset, Links
 - **Extension Maturity Classification:** Proposal

--- a/best-practices.md
+++ b/best-practices.md
@@ -145,7 +145,7 @@ leading to a new MLM STAC Item definition (see also [STAC Version Extension](#ve
 {
   "id": "stac-item-model",
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"
   ],
   "assets": {
@@ -216,7 +216,7 @@ that the model is properly instantiated from the expected weights, or that suffi
 ```json
 {
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],
   "assets": {

--- a/best-practices.md
+++ b/best-practices.md
@@ -145,7 +145,7 @@ leading to a new MLM STAC Item definition (see also [STAC Version Extension](#ve
 {
   "id": "stac-item-model",
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"
   ],
   "assets": {
@@ -216,7 +216,7 @@ that the model is properly instantiated from the expected weights, or that suffi
 ```json
 {
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
     "https://stac-extensions.github.io/file/v2.1.0/schema.json"
   ],
   "assets": {

--- a/examples/item_basic.json
+++ b/examples/item_basic.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json"
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "example-model",

--- a/examples/item_basic.json
+++ b/examples/item_basic.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "example-model",

--- a/examples/item_eo_bands.json
+++ b/examples/item_eo_bands.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",

--- a/examples/item_eo_bands.json
+++ b/examples/item_eo_bands.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",

--- a/examples/item_multi_io.json
+++ b/examples/item_multi_io.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"

--- a/examples/item_multi_io.json
+++ b/examples/item_multi_io.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"

--- a/examples/item_raster_bands.json
+++ b/examples/item_raster_bands.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"

--- a/examples/item_raster_bands.json
+++ b/examples/item_raster_bands.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+    "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
+  "$id": "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json",
   "title": "Machine Learning Model STAC Extension Schema",
   "description": "This object represents the metadata for a Machine Learning Model (MLM) used in STAC documents.",
   "oneOf": [
@@ -97,7 +97,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
+            "const": "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json"
           }
         }
       }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/mlm/v1.0.0/schema.json",
+  "$id": "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json",
   "title": "Machine Learning Model STAC Extension Schema",
   "description": "This object represents the metadata for a Machine Learning Model (MLM) used in STAC documents.",
   "oneOf": [
@@ -97,7 +97,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://stac-extensions.github.io/mlm/v1.0.0/schema.json"
+            "const": "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml -i .remarkignore",
     "format-markdown": "remark . -f -r .github/remark.yaml -i .remarkignore -o",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/mlm/v1.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/mlm/v1.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml -i .remarkignore",
     "format-markdown": "remark . -f -r .github/remark.yaml -i .remarkignore -o",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^8.0.0",

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,6 +55,31 @@ toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
 
 [[package]]
+name = "bump-my-version"
+version = "0.20.2"
+description = "Version bump your Python project"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "bump_my_version-0.20.2-py3-none-any.whl", hash = "sha256:71a641ca40bcc795fbbb72a69b366ac9f45d990a5be32d2419cb1a89d9cf6bd3"},
+    {file = "bump_my_version-0.20.2.tar.gz", hash = "sha256:63357ec65543b566eaf6fef4691b94c3032a19463428f11bf5601f9f668d59ce"},
+]
+
+[package.dependencies]
+click = "*"
+pydantic = ">=2.0.0"
+pydantic-settings = "*"
+questionary = "*"
+rich = "*"
+rich-click = "*"
+tomlkit = "*"
+
+[package.extras]
+dev = ["generate-changelog (>=0.7.6)", "git-fame (>=1.12.2)", "pip-tools", "pre-commit"]
+docs = ["black", "markdown-customblocks", "mdx-truly-sane-lists", "mkdocs", "mkdocs-click", "mkdocs-drawio", "mkdocs-gen-files", "mkdocs-git-authors-plugin", "mkdocs-git-committers-plugin", "mkdocs-git-revision-date-localized-plugin", "mkdocs-include-markdown-plugin", "mkdocs-literate-nav", "mkdocs-material", "mkdocstrings[python]", "python-frontmatter"]
+test = ["coverage", "freezegun", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytest-sugar"]
+
+[[package]]
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -630,6 +655,20 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.36"
+description = "Library for building powerful interactive command lines in Python"
+optional = false
+python-versions = ">=3.6.2"
+files = [
+    {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
+    {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 description = "Get CPU info with pure Python"
@@ -749,6 +788,25 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pydantic-settings"
+version = "2.2.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.2.1-py3-none-any.whl", hash = "sha256:0235391d26db4d2190cb9b31051c4b46882d28a51533f97440867f012d4da091"},
+    {file = "pydantic_settings-2.2.1.tar.gz", hash = "sha256:00b9f6a5e95553590434c0fa01ead0b216c3e10bc54ae02e37f359948643c5ed"},
+]
+
+[package.dependencies]
+pydantic = ">=2.3.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pydoclint"
@@ -979,6 +1037,20 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -1039,6 +1111,20 @@ files = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.0.1"
+description = "Python library to build pretty command line user prompts ⭐️"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "questionary-2.0.1-py3-none-any.whl", hash = "sha256:8ab9a01d0b91b68444dff7f6652c1e754105533f083cbe27597c8110ecc230a2"},
+    {file = "questionary-2.0.1.tar.gz", hash = "sha256:bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b"},
+]
+
+[package.dependencies]
+prompt_toolkit = ">=2.0,<=3.0.36"
+
+[[package]]
 name = "referencing"
 version = "0.34.0"
 description = "JSON Referencing + Python"
@@ -1091,6 +1177,25 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rich-click"
+version = "1.7.4"
+description = "Format click help output nicely with rich"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "rich-click-1.7.4.tar.gz", hash = "sha256:7ce5de8e4dc0333aec946113529b3eeb349f2e5d2fafee96b9edf8ee36a01395"},
+    {file = "rich_click-1.7.4-py3-none-any.whl", hash = "sha256:e363655475c60fec5a3e16a1eb618118ed79e666c365a36006b107c17c93ac4e"},
+]
+
+[package.dependencies]
+click = ">=7"
+rich = ">=10.7.0"
+typing-extensions = "*"
+
+[package.extras]
+dev = ["flake8", "flake8-docstrings", "mypy", "packaging", "pre-commit", "pytest", "pytest-cov", "types-setuptools"]
 
 [[package]]
 name = "rpds-py"
@@ -1472,6 +1577,17 @@ files = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.12.4"
+description = "Style preserving TOML library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomlkit-0.12.4-py3-none-any.whl", hash = "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b"},
+    {file = "tomlkit-0.12.4.tar.gz", hash = "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"},
+]
+
+[[package]]
 name = "typer"
 version = "0.9.4"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1543,7 +1659,18 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "06fb206fe0cc4eafcb151f75a9276436489a3423ca0cf59b6a2e479b51e4d934"
+content-hash = "1b99245b4f3a59a9cf8568091386e65262d4315bce093950fdbea90e77dac407"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ruff = "^0.2.2"
 bump-my-version = "^0.20.2"
 
 [tool.bumpversion]
-current_version = "0.0.0"
+current_version = "1.0.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,40 @@ pytest-click = "^1.1.0"
 pytest-pikachu = "^1.0.0"
 coverage = "^7.3.0"
 ruff = "^0.2.2"
+bump-my-version = "^0.20.2"
+
+[tool.bumpversion]
+current_version = "0.0.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = true
+ignore_missing_files = false
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = true
+commit_args = "--no-verify"
+message = "Bump version: {current_version} → {new_version}"
+
+[[tool.bumpversion.files]]
+glob = "**/*.json"
+search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
+replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
+
+[[tool.bumpversion.files]]
+glob = "**/*.md"
+search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
+replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
+
+[[tool.bumpversion.files]]
+glob = "**/*.py"
+search = "https://crim-ca.github.io/mlm-extension/v{current_version}/schema.json"
+replace = "https://crim-ca.github.io/mlm-extension/v{new_version}/schema.json"
 
 [tool.ruff]
 exclude = [

--- a/stac_model/schema.py
+++ b/stac_model/schema.py
@@ -37,7 +37,7 @@ T = TypeVar(
 )
 
 SchemaName = Literal["mlm"]
-SCHEMA_URI: str = "https://stac-extensions.github.io/mlm/v1.0.0/schema.json"
+SCHEMA_URI: str = "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
 PREFIX = f"{get_args(SchemaName)[0]}:"
 
 

--- a/stac_model/schema.py
+++ b/stac_model/schema.py
@@ -37,7 +37,7 @@ T = TypeVar(
 )
 
 SchemaName = Literal["mlm"]
-SCHEMA_URI: str = "https://crim-ca.github.io/mlm-extension/v0.0.0/schema.json"
+SCHEMA_URI: str = "https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json"
 PREFIX = f"{get_args(SchemaName)[0]}:"
 
 


### PR DESCRIPTION
## Description

- adjust schema URI with CRIM-ca org and MLM repo to provide an official endpoint hosting the schema
- add bump-my-version to allow automation of releases as necessary


