### PR TITLE
deprecate in favor of https://github.com/crim-ca/mlm-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - n/a
 
 ### Deprecated
-- n/a
+- The `dlm-extension` endpoint is itself deprecated in favor of
+  [`mlm-extension`](https://github.com/crim-ca/mlm-extension) (a direct fork of `dlm-extension`)
+  with the corresponding schema hosted on
+  [https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json](https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json).
 
 ### Removed
 - n/a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Machine Learning Model Extension Specification
 
+> :info: <br>
+> Formerly *Deep Learning Model (DLM) Extension Specification*
+
+> :warning: <br>
+> This repository is deprecated in favor of
+> [https://github.com/crim-ca/mlm-extension](https://github.com/crim-ca/mlm-extension). <br>
+> The corresponding schemas are made available on
+> [https://crim-ca.github.io/mlm-extension/](https://crim-ca.github.io/mlm-extension/).
+
 [![hackmd-github-sync-badge](https://hackmd.io/lekSD_RVRiquNHRloXRzeg/badge)](https://hackmd.io/lekSD_RVRiquNHRloXRzeg?both)
 
 - **Title:** Machine Learning Model Extension

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Machine Learning Model Extension Specification
 
-> :info: <br>
+> :information_source: <br>
 > Formerly *Deep Learning Model (DLM) Extension Specification*
 
 > :warning: <br>


### PR DESCRIPTION
## Description

Deprecation of this version to use the official endpoint schema provided at https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json
